### PR TITLE
Fix admin role, double bootstrap, and currentUser data

### DIFF
--- a/my-app/src/app/(auth)/oauth/callback/page.tsx
+++ b/my-app/src/app/(auth)/oauth/callback/page.tsx
@@ -112,6 +112,7 @@ export default function OAuthCallbackPage() {
           handle: me.handle ?? "",
           avatarUrl: me.avatar_url ?? null,
           isVerified: me.is_verified ?? false,
+          systemRole: (me.system_role as "ADMIN" | "MODERATOR" | "USER") ?? "USER",
         });
 
         const returnTo = sessionStorage.getItem("oauth_return_to") || "/discover";

--- a/my-app/src/app/auth/callback/page.tsx
+++ b/my-app/src/app/auth/callback/page.tsx
@@ -121,6 +121,7 @@ export default function AuthCallbackPage() {
           handle: me.handle ?? "",
           avatarUrl: me.avatar_url ?? null,
           isVerified: me.is_verified ?? false,
+          systemRole: (me.system_role as "ADMIN" | "MODERATOR" | "USER") ?? "USER",
         });
 
         // Redirect to wherever the user wanted to go (default: /discover)

--- a/my-app/src/hooks/useAuthInit.ts
+++ b/my-app/src/hooks/useAuthInit.ts
@@ -59,6 +59,13 @@ function entitlementsToSubDetails(e: BootstrapEntitlements): SubscriptionDetails
 
 export const useAuthInit = () => {
   useEffect(() => {
+    // Skip on OAuth callback pages — they call bootstrap themselves and
+    // set the auth store before redirecting. Running it again here would
+    // make two identical network calls on every OAuth login.
+    if (typeof window !== "undefined" && window.location.pathname.endsWith("/callback")) {
+      return;
+    }
+
     getBootstrapData()
       .then((data) => {
         // Seed profile store (minimal shell data; full profile loaded by profile page)

--- a/my-app/src/store/useAdminStore.ts
+++ b/my-app/src/store/useAdminStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { adminService } from '@/src/services/admin/adminService';
 import { useAuthStore } from '@/src/store/useAuthStore';
+import { useProfileStore } from '@/src/store/useProfileStore';
+import { useSubscriptionStore } from '@/src/store/useSubscriptionStore';
 import { ActionPayload } from "@/src/types/admin";
 import {
   AdminUser,
@@ -81,10 +83,15 @@ export const useAdminStore = create<AdminState>()(
             analytics: data.analytics
           });
 
-          // Sync currentUser from the auth store (set during login/getMe/bootstrap).
-          // Always refresh role fields so persisted stale roles cannot block admin UI.
+          // Sync currentUser from live stores — always refreshed so stale
+          // persisted roles can never block the admin UI after a role change.
           const authUser = useAuthStore.getState().user;
           if (authUser) {
+            const subType = useSubscriptionStore.getState().sub?.subscriptionType;
+            const accountType: AdminUser['account_type'] =
+              subType === 'PRO' || subType === 'GO+' ? 'PRO' : 'FREE';
+            const trackCount = useProfileStore.getState().tracksCount ?? 0;
+
             set({
               currentUser: {
                 id: authUser.id,
@@ -96,8 +103,8 @@ export const useAdminStore = create<AdminState>()(
                 is_verified: authUser.isVerified ?? false,
                 created_at: new Date().toISOString(),
                 avatar_url: authUser.avatarUrl ?? null,
-                account_type: 'FREE',
-                track_count: 0,
+                account_type: accountType,
+                track_count: trackCount,
                 report_count: 0,
                 last_login_at: new Date().toISOString(),
               },


### PR DESCRIPTION
- auth/callback + oauth/callback: add systemRole to setUser so ADMIN accounts get correct privileges immediately on OAuth login (without this the admin layout sees systemRole=undefined and redirects away)
- useAuthInit: skip bootstrap when pathname ends with /callback to prevent the double network call that occurred on every OAuth login
- useAdminStore: replace hardcoded track_count:0 / account_type:'FREE' with live values from profileStore.tracksCount and subscriptionStore

All 573 tests pass.