### PR TITLE
Fix admin login: redirect to /admin after OAuth, add sidebar link

### DIFF
--- a/my-app/src/app/(auth)/oauth/callback/page.tsx
+++ b/my-app/src/app/(auth)/oauth/callback/page.tsx
@@ -117,7 +117,9 @@ export default function OAuthCallbackPage() {
 
         const returnTo = sessionStorage.getItem("oauth_return_to") || "/discover";
         sessionStorage.removeItem("oauth_return_to");
-        router.replace(returnTo);
+        // Admins and moderators land on the dashboard, not the listener feed
+        const isStaff = me.system_role === "ADMIN" || me.system_role === "MODERATOR";
+        router.replace(isStaff && returnTo === "/discover" ? "/admin" : returnTo);
       } catch {
         setError("Login failed. Please try again.");
       }

--- a/my-app/src/app/auth/callback/page.tsx
+++ b/my-app/src/app/auth/callback/page.tsx
@@ -128,7 +128,9 @@ export default function AuthCallbackPage() {
         const returnTo = sessionStorage.getItem("oauth_return_to") || "/discover";
         sessionStorage.removeItem("oauth_return_to");
         sessionStorage.removeItem("oauth_provider");
-        router.replace(returnTo);
+        // Admins and moderators land on the dashboard, not the listener feed
+        const isStaff = me.system_role === "ADMIN" || me.system_role === "MODERATOR";
+        router.replace(isStaff && returnTo === "/discover" ? "/admin" : returnTo);
       } catch {
         setError("Login failed. Please try again.");
       }

--- a/my-app/src/components/ui/SideBar.tsx
+++ b/my-app/src/components/ui/SideBar.tsx
@@ -3,6 +3,7 @@ import Box from "@/src/components/ui/Box";
 import SideBarItem from "@/src/components/ui/SideBarItem";
 import SuggestedArtists from "@/src/components/profile/sidebar/SuggestedArtists";
 import { useFollowStore } from "@/src/store/followStore";
+import { useAuthStore } from "@/src/store/useAuthStore";
 
 interface SideBarProps {
   children: React.ReactNode;
@@ -14,6 +15,8 @@ const SideBar: React.FC<SideBarProps> = ({ children, showSidebar = true }) => {
     (state) => state.suggestionsLoading,
   );
   const fetchSuggestions = useFollowStore((state) => state.fetchSuggestions);
+  const systemRole = useAuthStore((s) => s.user?.systemRole);
+  const isStaff = systemRole === "ADMIN" || systemRole === "MODERATOR";
 
   return (
     <div className="flex h-screen">
@@ -27,6 +30,14 @@ const SideBar: React.FC<SideBarProps> = ({ children, showSidebar = true }) => {
         className={`hidden md:flex flex-col gap-y-2 bg-[#121212] h-full w-96 p-2 
         ${showSidebar ? "visible" : "invisible"}`}
       >
+        {isStaff && (
+          <Box className="flex-1">
+            <div className="px-5 py-4">
+              <SideBarItem label="ADMIN DASHBOARD" href="/admin" />
+            </div>
+          </Box>
+        )}
+
         <Box className="flex-1">
           <div className="px-5 py-4">
             <SideBarItem label="ARTISTS TOOLS" href="/" />


### PR DESCRIPTION
- Both OAuth callback pages now redirect ADMIN/MODERATOR to /admin instead of /discover when oauth_return_to is the default /discover
- SideBar shows ADMIN DASHBOARD link for ADMIN/MODERATOR users so there is always a visible entry point to the admin panel

All 573 tests pass.